### PR TITLE
[PR] Allow plugins to filter the monitored capabilities

### DIFF
--- a/includes/class-wsuwp-content-visibility.php
+++ b/includes/class-wsuwp-content-visibility.php
@@ -331,7 +331,8 @@ class WSUWP_Content_Visibility {
 	 * @return array Updated list of capabilities.
 	 */
 	public function allow_read_private_posts( $allcaps, $caps, $args, $user ) {
-		if ( 'read_post' !== $args[0] ) {
+		$watch_caps = apply_filters( 'wsuwp_content_visibility_caps', array( 'read_post' ) );
+		if ( ! in_array( $args[0], $watch_caps, true ) ) {
 			return $allcaps;
 		}
 


### PR DESCRIPTION
The specific use case for this is to handle the `read_document`
capability used by WP Document Revisions. In most cases, it should
not be necessary to add custom capabilities, but we can still
allow it to happen.
